### PR TITLE
Addition of scintillator level PI addresses to pilist.py

### DIFF
--- a/SNOPlusSlowControl/DB/pilist.py
+++ b/SNOPlusSlowControl/DB/pilist.py
@@ -38,12 +38,16 @@ pi_list =[{"dbname":"UPW_plant_temp","channels":[1],"address":"DeltaV_311-TIT-14
               {"dbname":"UPS_input_voltage","channels":[1,2,3],"address":"SNMP_snoplusups01_upsInputVoltageLine%s.CV","appendage":["1","2","3"],"method":3},\
               {"dbname":"UPS_output_power","channels":[1,2,3],"address":"SNMP_snoplusups01_upsOutputPowerLine%s.CV","appendage":["1","2","3"],"method":3},\
               {"dbname":"UPS_output_voltage","channels":[1,2,3],"address":"SNMP_snoplusups01_upsOutputVoltageLine%s.CV","appendage":["1","2","3"],"method":3},\
-              {"dbname":"AV_dP","channels":[1],"address":"DeltaV_321-DPT002/SCLR1/OUT.CV","method":1}]
+              {"dbname":"AV_dP","channels":[1],"address":"DeltaV_321-DPT002/SCLR1/OUT.CV","method":1},\
+              {"dbname":"AV_scint_height","channels":[1],"address":"DeltaV_LIC-AV-01-MOD/PID1/PV.CV","method":1},\
+              {"dbname":"cavity_bathtub","channels":[1],"address":"DeltaV_311-LIT-100/AI1/PV.CV","method":1},\
+              {"dbname":"scint_volume_calc","channels":[1],"address":"DeltaV_FIC-AV-01-MOD-PID1/TOTALIZER.CV","method":1}]
 #Any dbs not in this list will search for new data in the most recent minute according to now's time
 #Any dbs in this list grab the most recent data point in the PI server
 getrecent_list = ["deck_humidity","deck_temp","control_room_temp","cover_gas","equator_monitor","AVsensorRope","AVneck",\
         "CavityRecircValveIsOpen","AVRecircValveIsOpen","P15IsRunning",\
 	"UPS_output_load","UPS_time_on_battery","UPS_estimated_time_left",\
 	"UPS_battery_status","UPS_output_power","UPS_output_voltage",\
-	"UPS_input_voltage","P16IsRunning"]
+	"UPS_input_voltage","P16IsRunning","AV_scint_height","cavity_level_bathtub",\
+	"scint_volume_calc"]
 


### PR DESCRIPTION
Added the PI server addresses for scintillator level data.  snoplus-channeldb on couch.snopl.us also updated to have threshold information for alarms associated with data values.