### PR TITLE
Modify some defaults in configurations to be universal to IOS and Minard installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@ SNO+ Slow Control scripts for collecting and storing PI DB and IOS data
 This repository contains all of the slow control scripts and libraries used by the IO servers
 and Minard server to collect and store SNO+ detector data on a couch database.
 
+######## QUICK INSTALL ONTO MINARD OR AN IOS #############
+
+1. Pull this repository into the home directory on the new IOS or Minard.
+2. Make a '/config/' directory in the home directory with the credentials
+needed for accessing the slow control e-mail account, alarmdb, and couchdb.  File
+contents have the form:
+
+username type_the_username
+password type_the_password
+
+3. Enter the ~/SNOPlusSlowControl/SNOPlusSlowControl/lib/config directory and 
+modify configurables as needed.  Likely, the only changes you need are to IOSNUM
+and any changes to couchdb database or couchdb view names.
+
+4. Install cronjob scripts found in /cronjobs/ on your IOS or Minard account.  These
+will run regular checks to see if the slow control scripts have stopped working,
+check the local memory and see if there's a risk of filling the drive, etc.
+
+5. Start up the polling with the checkpi_db.sh  or checkPoll.sh bash scripts
+found in the /cronjobs/ directory.
+
+######## SUMMARY OF CONTENTS IN EACH DIRECTORY #########
 
 /misclib/: directory with miscillaneous libraries that were installed for use
 with the pi_db and ios scripts.  Most other dependencies are common python libraries.
@@ -18,7 +40,12 @@ of these scripts before using them on your machine.
 The main operating scripts is for Minard pi_db/main_pidb.py, which uses the database libraries
 contained in SNOPlusSlowControl/lib/.  The same goes for the IO servers and pi_db/main_ios.py.  Names of relevant database URLs, settings for interval
 time between polling, and other configurables loaded are adjusted in
-lib/config/config_pidb.py and lib/config/config_ios.py.  
+lib/config/config_pidb.py and lib/config/config_ios.py. 
+
+/SNOPlusSlowcControl/DB/: Contains dictionaries that instruct main_pidb.py on
+what type of data to poll from the PI server.  You will have to add new PI 
+server addresses here to expand the data copied from the PI server to the 
+SNO+ couch databases.
 
 /util/: Additional scripts that have been developed for monitoring
 other components of the SNO+ detector.  In principle, they could

--- a/SNOPlusSlowControl/lib/config/alarmdbconfig.py
+++ b/SNOPlusSlowControl/lib/config/alarmdbconfig.py
@@ -1,6 +1,5 @@
 #Information for connecting to alarm GUI postgres database
-#ALARMCREDDIR = "~/config/alascred.conf"
-ALARMCREDDIR = "/home/slowcontroller/config/alascred.conf"
+ALARMCREDDIR = "~/config/alascred.conf"
 ALARMHOST = "dbug.sp.snolab.ca"
 ALARMDBNAME = "detector"
 

--- a/SNOPlusSlowControl/lib/config/iosconfig.py
+++ b/SNOPlusSlowControl/lib/config/iosconfig.py
@@ -7,9 +7,9 @@ LOWVOLTTHRESH = 1.5
 #RETRYONTIMEOUT=True
 
 CHDBADDRESS = 'http://couch.snopl.us'
-CHDBCREDS = "/home/slowcontroller/config/couchcred.conf"
+CHDBCREDS = "~/config/couchcred.conf"
 SCCOUCHADDRESS = "http://localhost:5984/" #IOS saves data to their local couchDB & replicated
-SCCOUCHCREDS = "/home/slowcontroller/config/SCcouchcred.conf"
+SCCOUCHCREDS = "~/config/SCcouchcred.conf"
 IOSCARDCONF = "/home/slowcontroller/hmhj/lib/hmhj_layer1-0.2/priv/cards.conf"
 CHANNELDBURL = 'slowcontrol-channeldb'
 CHANNELDBVIEW = 'slowcontrol/recent'

--- a/SNOPlusSlowControl/lib/config/logconfig.py
+++ b/SNOPlusSlowControl/lib/config/logconfig.py
@@ -1,13 +1,10 @@
 import logging
 
 #LOCAL LOGGING CONFIGURATIOn
-LOG_FILENAME = '/home/slowcontroller/SNOPlusSlowControl/SNOPlusSlowControl/log/IOSlog.log' #logfile source on IOSes
-#LOG_FILENAME = '/home/slowcontroller/SNOPlusSlowControl/SNOPlusSlowControl/log/pilog.log' #logfile source on minard
+LOG_FILENAME = '~/SNOPlusSlowControl/SNOPlusSlowControl/log/IOSlog.log' #logfile source assuming homedir install
 LOG_FORMAT = '%(asctime)s %(name)8s %(levelname)5s %(message)s'
 LOG_LEVEL = logging.INFO
 
-#EMAIL LIST FOR SENDING ALARMS/MESSAGES TO
-#GMAILCREDS = "/home/slowcontroller/config/gmailcred.conf"
-GMAILCREDS = "/home/slowcontroller/config/gmailcred.conf"
-#EMAIL_RECIPIENTS_FILE = "/home/slowcontroller/SNOPlusSlowControl/SNOPlusSlowControl/DB/emailList.txt"
-EMAIL_RECIPIENTS_FILE = "/home/slowcontroller/SNOPlusSlowControl/SNOPlusSlowControl/DB/emailList.txt"
+#EMAIL LIST FOR SENDING ALARMS/MESSAGES TO (Assumes homedir install)
+GMAILCREDS = "~/config/gmailcred.conf"
+EMAIL_RECIPIENTS_FILE = "~/SNOPlusSlowControl/SNOPlusSlowControl/DB/emailList.txt"

--- a/SNOPlusSlowControl/lib/config/pidbconfig.py
+++ b/SNOPlusSlowControl/lib/config/pidbconfig.py
@@ -1,5 +1,5 @@
 DEBUG = False
-ALARMCREDDIR = "/home/uwslowcontrol/config/alascred.conf"
+ALARMCREDDIR = "~/config/alascred.conf"
 ALARMHOST,ALARMDBNAME = "dbug","detector"
 
 TIMESERIESURL = 'http://pi.snolab.ca/PIWebServices/PITimeSeries.svc?wsdl'
@@ -8,7 +8,7 @@ PIADDRESSBASE = "pi:\\\\pi.snolab.ca\\"
  
 
 COUCHADDRESS = 'http://couch.snopl.us'
-COUCHCREDS = "/home/uwslowcontrol/config/couchcred.conf"
+COUCHCREDS = "~/config/couchcred.conf"
 CHANNELDBVIEW = 'slowcontrol/recent'
 CHANNELDBURL = 'slowcontrol-channeldb'
 ONEMINDBURL = "slowcontrol-data-1min"


### PR DESCRIPTION
Explicit definition of directories required configuration files to be modified for implementation on either the IOSes or the Minard Server.  Instead, the default now assumes SNOPlusSlowControl is installed in the home directory.  This is currently true for all IOSes and the Minard Server installation.

The README has been updated with information regarding this point.  When using this code, the user must either operate from the home directory, or modify the config files to reflect the explicit path of installation.